### PR TITLE
fix: update operator in binary expression to use correct operator

### DIFF
--- a/test/rules/no-negated-disjunction.test.ts
+++ b/test/rules/no-negated-disjunction.test.ts
@@ -546,6 +546,19 @@ ruleTester.run('noNegatedDisjunction', rule, {
       output: "if (!('a' in x) && !('b' in x)) {}",
       code: "if (!('a' in x || 'b' in x)) {}",
     },
+    {
+      errors: [
+        {
+          data: {
+            original: "!(a instanceof A || b instanceof B)",
+            fixed: "!(a instanceof A) && !(b instanceof B)",
+          },
+          messageId: 'convertNegatedDisjunction',
+        },
+      ],
+      output: "if (!(a instanceof A) && !(b instanceof B)) {}",
+      code: "if (!(a instanceof A || b instanceof B)) {}",
+    }
   ],
   valid: [
     'if (!a) {}',

--- a/test/rules/no-negated-disjunction.test.ts
+++ b/test/rules/no-negated-disjunction.test.ts
@@ -550,15 +550,15 @@ ruleTester.run('noNegatedDisjunction', rule, {
       errors: [
         {
           data: {
-            original: "!(a instanceof A || b instanceof B)",
-            fixed: "!(a instanceof A) && !(b instanceof B)",
+            original: '!(a instanceof A || b instanceof B)',
+            fixed: '!(a instanceof A) && !(b instanceof B)',
           },
           messageId: 'convertNegatedDisjunction',
         },
       ],
-      output: "if (!(a instanceof A) && !(b instanceof B)) {}",
-      code: "if (!(a instanceof A || b instanceof B)) {}",
-    }
+      output: 'if (!(a instanceof A) && !(b instanceof B)) {}',
+      code: 'if (!(a instanceof A || b instanceof B)) {}',
+    },
   ],
   valid: [
     'if (!a) {}',

--- a/utils/toggle-negation.ts
+++ b/utils/toggle-negation.ts
@@ -57,7 +57,7 @@ let toggleBinaryExpression = (
   ]
 
   if (notTransformableOperators.includes(node.operator)) {
-    return `!(${left} in ${right})`
+    return `!(${left} ${node.operator} ${right})`
   }
 
   let operatorMap: Record<string, BinaryOperator> = {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The previous implementation always used `in` for unsupported operators, which caused issues.
Now, it correctly uses `node.operator` to apply the proper operator in the expression.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-de-morgan/blob/main/contributing.md).
