### PR TITLE
feat: prevent unsafe negation transformations

### DIFF
--- a/rules/no-negated-conjunction.ts
+++ b/rules/no-negated-conjunction.ts
@@ -1,5 +1,7 @@
 import type { Rule } from 'eslint'
 
+import { hasNegationInsideParentheses } from '../utils/has-negation-inside-parentheses'
+import { hasBooleanContext } from '../utils/has-boolean-context'
 import { flattenOperands } from '../utils/flatten-operands'
 import { getNodeContent } from '../utils/get-node-content'
 import { toggleNegation } from '../utils/toggle-negation'
@@ -12,11 +14,11 @@ import { isNegated } from '../utils/is-negated'
 export default {
   create: context => ({
     UnaryExpression: node => {
-      if (
-        isNegated(node) &&
-        isConjunction(node.argument) &&
-        isPureGroup(node, context)
-      ) {
+      let isNegatedConjunction = isNegated(node) && isConjunction(node.argument)
+      let hasPureOuterGroup = isPureGroup(node, context)
+      let isSafeToFix =
+        hasBooleanContext(node) || !hasNegationInsideParentheses(node, context)
+      if (isNegatedConjunction && hasPureOuterGroup && isSafeToFix) {
         let originalExpression = getNodeContent(node, context)
         let toggledOperands = flattenOperands({
           transformer: toggleNegation,

--- a/test/rules/no-negated-conjunction.test.ts
+++ b/test/rules/no-negated-conjunction.test.ts
@@ -93,19 +93,6 @@ ruleTester.run('noNegatedConjunction', rule, {
       errors: [
         {
           data: {
-            original: '!(a && !b)',
-            fixed: '!a || b',
-          },
-          messageId: 'convertNegatedConjunction',
-        },
-      ],
-      code: 'foo(!(a && !b))',
-      output: 'foo(!a || b)',
-    },
-    {
-      errors: [
-        {
-          data: {
             original: '!(a && b)',
             fixed: '!a || !b',
           },
@@ -568,5 +555,6 @@ ruleTester.run('noNegatedConjunction', rule, {
     'if (!(a && b || c)) {}',
     'if (!(a || b && c)) {}',
     'if (!((a && b) || c)) {}',
+    'foo(!(a && !b))',
   ],
 })

--- a/test/rules/no-negated-disjunction.test.ts
+++ b/test/rules/no-negated-disjunction.test.ts
@@ -93,19 +93,6 @@ ruleTester.run('noNegatedDisjunction', rule, {
       errors: [
         {
           data: {
-            original: '!(a || !b)',
-            fixed: '!a && b',
-          },
-          messageId: 'convertNegatedDisjunction',
-        },
-      ],
-      code: 'foo(!(a || !b))',
-      output: 'foo(!a && b)',
-    },
-    {
-      errors: [
-        {
-          data: {
             original: '!(a || b)',
             fixed: '!a && !b',
           },
@@ -582,5 +569,6 @@ ruleTester.run('noNegatedDisjunction', rule, {
     'if (!(a && b || c)) {}',
     'if (!((a || b) && c)) {}',
     'if (!!(a || b)) {}',
+    'foo(!(a || !b))',
   ],
 })

--- a/test/utils/find-outermost-parenthesized-node.test.ts
+++ b/test/utils/find-outermost-parenthesized-node.test.ts
@@ -1,0 +1,70 @@
+import type { LogicalExpression, Expression } from 'estree'
+
+import { describe, expect, it } from 'vitest'
+
+import { findOutermostParenthesizedNode } from '../../utils/find-outermost-parenthesized-node'
+
+interface FakeLogicalExpression extends LogicalExpression {
+  parent?: FakeLogicalExpression
+  range: [number, number]
+}
+
+type FakeNode = {
+  range: [number, number]
+  parent?: FakeNode
+} & Expression
+
+let createNode = (range: [number, number], parent?: FakeNode): FakeNode => ({
+  type: 'Identifier',
+  name: 'a',
+  parent,
+  range,
+})
+
+let createLogicalExpression = (
+  range: [number, number],
+  parent?: FakeLogicalExpression,
+): FakeLogicalExpression => ({
+  type: 'LogicalExpression',
+  right: createNode([2, 3]),
+  left: createNode([0, 1]),
+  operator: '&&',
+  parent,
+  range,
+})
+
+describe('findOutermostParenthesizedNode', () => {
+  it('should return the same node if it is already wrapped in parentheses', () => {
+    let sourceCode = '(a && b)'
+    let node = createLogicalExpression([1, 6])
+    let result = findOutermostParenthesizedNode(node, sourceCode)
+    expect(result).toBe(node)
+  })
+
+  it('should return the topmost logical expression if no parentheses exist', () => {
+    let sourceCode = 'a && b && c'
+    let node = createLogicalExpression([0, 9])
+    let result = findOutermostParenthesizedNode(node, sourceCode)
+    expect(result).toBe(node)
+  })
+
+  it('should return the node itself if it is already in parentheses', () => {
+    let sourceCode = '(a || b)'
+    let node = createLogicalExpression([1, 7])
+    let result = findOutermostParenthesizedNode(node, sourceCode)
+    expect(result).toBe(node)
+  })
+
+  it('should stop at the first encountered parenthesized ancestor', () => {
+    let sourceCode = '(a || (b && c))'
+
+    let innerNode = createLogicalExpression([6, 11])
+    let middleNode = createLogicalExpression([5, 12], innerNode)
+    let outerNode = createLogicalExpression([1, 13], middleNode)
+    innerNode.parent = middleNode
+    middleNode.parent = outerNode
+
+    let result = findOutermostParenthesizedNode(innerNode, sourceCode)
+    expect(result).toBe(outerNode)
+  })
+})

--- a/test/utils/flatten-operands.test.ts
+++ b/test/utils/flatten-operands.test.ts
@@ -28,11 +28,11 @@ let fakeContext: Rule.RuleContext = {
   },
 } as unknown as Rule.RuleContext
 
-let isConjunctionFake = (expr: Expression): boolean =>
-  expr.type === 'LogicalExpression' && expr.operator === '&&'
+let isConjunctionFake = (expression: Expression): boolean =>
+  expression.type === 'LogicalExpression' && expression.operator === '&&'
 
-let simpleTransformer = (expr: Expression): string =>
-  fakeContext.sourceCode.getText(expr)
+let simpleTransformer = (expression: Expression): string =>
+  fakeContext.sourceCode.getText(expression)
 
 let createIdentifier = (
   name: string,
@@ -136,10 +136,12 @@ describe('flattenOperands', () => {
   it('should stop processing when maximum recursion depth is exceeded', () => {
     let deepExpression = createNestedConjunction(110)
     let result = flattenOperands({
-      transformer: (expr: Expression, context: Rule.RuleContext): string =>
-        getNodeContent(expr, context).trim(),
-      predicate: (expr: Expression): boolean =>
-        expr.type === 'LogicalExpression' && expr.operator === '&&',
+      transformer: (
+        expression: Expression,
+        context: Rule.RuleContext,
+      ): string => getNodeContent(expression, context).trim(),
+      predicate: (expression: Expression): boolean =>
+        expression.type === 'LogicalExpression' && expression.operator === '&&',
       expression: deepExpression,
       context: fakeContext,
     })

--- a/test/utils/has-boolean-context.test.ts
+++ b/test/utils/has-boolean-context.test.ts
@@ -1,0 +1,173 @@
+import type {
+  ConditionalExpression,
+  LogicalExpression,
+  BinaryExpression,
+  DoWhileStatement,
+  MemberExpression,
+  UnaryExpression,
+  CallExpression,
+  WhileStatement,
+  ForStatement,
+  IfStatement,
+  Identifier,
+  Node,
+} from 'estree'
+
+import { describe, expect, it } from 'vitest'
+
+import { hasBooleanContext } from '../../utils/has-boolean-context'
+
+type FakeNode<T extends Node> = { parent?: Node } & T
+
+describe('hasBooleanContext', () => {
+  it('should return true when inside an IfStatement condition', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'a' }
+    let node: FakeNode<IfStatement> = {
+      consequent: { type: 'BlockStatement', body: [] },
+      type: 'IfStatement',
+      test: testNode,
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeTruthy()
+  })
+
+  it('should return true when inside a WhileStatement condition', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'b' }
+    let node: FakeNode<WhileStatement> = {
+      body: { type: 'BlockStatement', body: [] },
+      type: 'WhileStatement',
+      test: testNode,
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeTruthy()
+  })
+
+  it('should return true when inside a ForStatement test condition', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'i' }
+    let node: FakeNode<ForStatement> = {
+      body: { type: 'BlockStatement', body: [] },
+      type: 'ForStatement',
+      test: testNode,
+      update: null,
+      init: null,
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeTruthy()
+  })
+
+  it('should return true when inside a DoWhileStatement condition', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'c' }
+    let node: FakeNode<DoWhileStatement> = {
+      body: { type: 'BlockStatement', body: [] },
+      type: 'DoWhileStatement',
+      test: testNode,
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeTruthy()
+  })
+
+  it('should return true when inside a ConditionalExpression test', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'x' }
+    let node: FakeNode<ConditionalExpression> = {
+      consequent: { type: 'Literal', value: 1 },
+      alternate: { type: 'Literal', value: 0 },
+      type: 'ConditionalExpression',
+      test: testNode,
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeTruthy()
+  })
+
+  it('should return true when part of a LogicalExpression (&& operator)', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'a' }
+    let node: FakeNode<LogicalExpression> = {
+      right: { type: 'Identifier', name: 'b' },
+      type: 'LogicalExpression',
+      operator: '&&',
+      left: testNode,
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeTruthy()
+  })
+
+  it('should return true when part of a LogicalExpression (|| operator)', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'a' }
+    let node: FakeNode<LogicalExpression> = {
+      right: { type: 'Identifier', name: 'b' },
+      type: 'LogicalExpression',
+      operator: '||',
+      left: testNode,
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeTruthy()
+  })
+
+  it('should return true when part of a UnaryExpression with "!" operator', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'x' }
+    let node: FakeNode<UnaryExpression> = {
+      type: 'UnaryExpression',
+      argument: testNode,
+      operator: '!',
+      prefix: true,
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeTruthy()
+  })
+
+  it('should return false for a BinaryExpression with a non-boolean operator', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'a' }
+    let node: FakeNode<BinaryExpression> = {
+      right: { type: 'Identifier', name: 'b' },
+      type: 'BinaryExpression',
+      left: testNode,
+      operator: '+',
+    }
+    testNode.parent = node
+
+    expect(hasBooleanContext(testNode)).toBeFalsy()
+  })
+
+  it('should return false for a literal number', () => {
+    let node: FakeNode<Node> = {
+      type: 'Literal',
+      value: 123,
+    }
+
+    expect(hasBooleanContext(node)).toBeFalsy()
+  })
+
+  it('should return false when inside a non-Boolean function call', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'x' }
+    let nonBooleanCall: FakeNode<CallExpression> = {
+      callee: { name: 'someFunction', type: 'Identifier' },
+      type: 'CallExpression',
+      arguments: [testNode],
+      optional: false,
+    }
+    testNode.parent = nonBooleanCall
+
+    expect(hasBooleanContext(testNode)).toBeFalsy()
+  })
+
+  it('should return false when inside an object property access', () => {
+    let testNode: FakeNode<Identifier> = { type: 'Identifier', name: 'prop' }
+    let memberExpression: FakeNode<MemberExpression> = {
+      object: { type: 'Identifier', name: 'obj' },
+      type: 'MemberExpression',
+      property: testNode,
+      computed: false,
+      optional: false,
+    }
+    testNode.parent = memberExpression
+
+    expect(hasBooleanContext(testNode)).toBeFalsy()
+  })
+})

--- a/test/utils/has-negation-inside-parentheses.test.ts
+++ b/test/utils/has-negation-inside-parentheses.test.ts
@@ -1,0 +1,150 @@
+import type { LogicalExpression, UnaryExpression, Expression } from 'estree'
+import type { Rule } from 'eslint'
+
+import { describe, expect, it } from 'vitest'
+
+import { hasNegationInsideParentheses } from '../../utils/has-negation-inside-parentheses'
+
+interface FakeLogicalExpression extends LogicalExpression {
+  right: Expression
+  left: Expression
+  code: string
+}
+
+interface FakeUnaryExpression extends UnaryExpression {
+  argument: Expression
+  code: string
+}
+
+type FakeNode = {
+  range: [number, number]
+  parent?: FakeNode
+  code?: string
+} & Expression
+
+let fakeContext: Rule.RuleContext = {
+  sourceCode: {
+    getText: (node: { code?: string }) => node.code ?? '',
+  },
+} as unknown as Rule.RuleContext
+
+let createNegation = (
+  argument: Expression,
+  code: string,
+): FakeUnaryExpression => ({
+  type: 'UnaryExpression',
+  range: [0, code.length],
+  operator: '!',
+  prefix: true,
+  argument,
+  code,
+})
+
+let createLogicalExpression = ({
+  operator,
+  right,
+  left,
+  code,
+}: {
+  operator: '&&' | '||'
+  right: Expression
+  left: Expression
+  code: string
+}): FakeLogicalExpression => ({
+  type: 'LogicalExpression',
+  range: [0, code.length],
+  operator,
+  right,
+  left,
+  code,
+})
+
+let createIdentifier = (name: string): FakeNode => ({
+  range: [0, name.length],
+  type: 'Identifier',
+  code: name,
+  name,
+})
+
+describe('hasNegationInsideParentheses', () => {
+  it('should return true when a negation exists inside parentheses', () => {
+    let node = createNegation(createIdentifier('a'), '!a')
+    let wrappedNode = createNegation(node, '(!(a))')
+    expect(hasNegationInsideParentheses(wrappedNode, fakeContext)).toBeTruthy()
+  })
+
+  it('should return true when a negation is inside a logical expression in parentheses', () => {
+    let negatedNode = createNegation(createIdentifier('a'), '!a')
+    let logicalNode = createLogicalExpression({
+      right: createIdentifier('b'),
+      left: negatedNode,
+      code: '(!a && b)',
+      operator: '&&',
+    })
+    let wrappedNode = createNegation(logicalNode, '(!( !a && b ))')
+    expect(hasNegationInsideParentheses(wrappedNode, fakeContext)).toBeTruthy()
+  })
+
+  it('should return true when negations exist on both sides of a logical expression', () => {
+    let leftNegation = createNegation(createIdentifier('a'), '!a')
+    let rightNegation = createNegation(createIdentifier('b'), '!b')
+    let logicalNode = createLogicalExpression({
+      right: rightNegation,
+      left: leftNegation,
+      code: '(!a || !b)',
+      operator: '||',
+    })
+    let wrappedNode = createNegation(logicalNode, '(!( !a || !b ))')
+    expect(hasNegationInsideParentheses(wrappedNode, fakeContext)).toBeTruthy()
+  })
+
+  it('should return false when there are no negations inside the expression', () => {
+    let logicalNode = createLogicalExpression({
+      right: createIdentifier('b'),
+      left: createIdentifier('a'),
+      code: '(a && b)',
+      operator: '&&',
+    })
+    let wrappedNode = createNegation(logicalNode, '(!(a && b))')
+    expect(hasNegationInsideParentheses(wrappedNode, fakeContext)).toBeFalsy()
+  })
+
+  it('should return false when the expression is a simple identifier without negation', () => {
+    let node = createIdentifier('a')
+    expect(hasNegationInsideParentheses(node, fakeContext)).toBeFalsy()
+  })
+
+  it('should return false when there are nested logical expressions but no negations', () => {
+    let innerNode = createLogicalExpression({
+      right: createIdentifier('b'),
+      left: createIdentifier('a'),
+      code: '(a && b)',
+      operator: '&&',
+    })
+    let outerNode = createLogicalExpression({
+      right: createIdentifier('c'),
+      code: '((a && b) || c)',
+      left: innerNode,
+      operator: '||',
+    })
+    let wrappedNode = createNegation(outerNode, '(!( (a && b) || c ))')
+    expect(hasNegationInsideParentheses(wrappedNode, fakeContext)).toBeFalsy()
+  })
+
+  it('should return true when there is a negation deep inside a nested logical expression', () => {
+    let innerNode = createLogicalExpression({
+      left: createNegation(createIdentifier('a'), '!a'),
+      right: createIdentifier('b'),
+      code: '(!a && b)',
+      operator: '&&',
+    })
+    let outerNode = createLogicalExpression({
+      right: createIdentifier('c'),
+      code: '((!a && b) || c)',
+      left: innerNode,
+      operator: '||',
+    })
+    let wrappedNode = createNegation(outerNode, '(!( (!a && b) || c ))')
+    expect(hasNegationInsideParentheses(wrappedNode, fakeContext)).toBeTruthy()
+  })
+})

--- a/utils/find-outermost-parenthesized-node.ts
+++ b/utils/find-outermost-parenthesized-node.ts
@@ -1,0 +1,56 @@
+import type { Node } from 'estree'
+
+import { isLogicalExpression } from './is-logical-expression'
+
+type ParentedNode = { parent?: ParentedNode } & Node
+
+/**
+ * Checks if the characters immediately before and at the end of the given
+ * node's range in the source code form a pair of parentheses.
+ * @param {number} start - The start index of the node's range.
+ * @param {number} end - The end index of the node's range.
+ * @param {string} sourceCode - The full source code text.
+ * @returns {boolean} True if the character immediately before start is `(` and
+ * the character at index end is `)`, false otherwise.
+ */
+let isInParentheses = (
+  start: number,
+  end: number,
+  sourceCode: string,
+): boolean => sourceCode[start - 1] === '(' && sourceCode[end] === ')'
+
+/**
+ * Traverses up the parent chain of the given node (if available) to find the
+ * outermost logical expression node that is explicitly wrapped in parentheses.
+ * The function checks the node and its parents (while they are
+ * LogicalExpression) and returns the first node that is wrapped in parentheses
+ * (i.e. where the characters immediately before its range and at its end form a
+ * matching pair of parentheses). If none is found, the function returns the
+ * topmost LogicalExpression.
+ * @param {ParentedNode} node - The starting expression node.
+ * @param {string} sourceCode - The full source code text.
+ * @returns {ParentedNode} The outermost parenthesized node found in the parent
+ * chain.
+ */
+export let findOutermostParenthesizedNode = (
+  node: ParentedNode,
+  sourceCode: string,
+): ParentedNode => {
+  let current = node
+  let [start, end] = current.range!
+
+  if (isInParentheses(start, end, sourceCode)) {
+    return current
+  }
+
+  while (current.parent && isLogicalExpression(current)) {
+    current = current.parent
+    ;[start, end] = current.range!
+
+    if (isInParentheses(start, end, sourceCode)) {
+      return current
+    }
+  }
+
+  return current
+}

--- a/utils/has-boolean-context.ts
+++ b/utils/has-boolean-context.ts
@@ -1,0 +1,78 @@
+import type { BinaryOperator, Node } from 'estree'
+
+type ParentedNode = { parent?: Node } & Node
+
+/**
+ * Determines whether a given expression is used in a boolean context.
+ *
+ * Boolean contexts include conditions in control flow statements (`if`,
+ * `while`, `for`), logical expressions (`&&`, `||`), explicit boolean coercions
+ * (`!!`, `Boolean(expr)`), and comparison operations (`===`, `!==`, `<`, `>`).
+ * @param {ParentedNode} node - The AST node to check.
+ * @returns {boolean} True if the expression is used in a boolean context.
+ */
+export let hasBooleanContext = (node: ParentedNode): boolean =>
+  node.parent
+    ? isControlFlowBooleanContext(node.parent) ||
+      isComparison(node.parent) ||
+      isBooleanFunction(node.parent)
+    : false
+
+/**
+ * Checks if the given node is part of a control flow structure that expects a
+ * boolean value.
+ *
+ * These structures include:
+ * - `if (expr) {...}`
+ * - `while (expr) {...}`
+ * - `for (; expr; ) {...}`
+ * - `expr ? a : b` (ternary)
+ * - Logical expressions (`&&`, `||`)
+ * - Explicit coercion via `!!expr`
+ * @param {Node} parent - The parent node in the AST.
+ * @returns {boolean} True if the node is in a boolean context.
+ */
+let isControlFlowBooleanContext = (parent: Node): boolean =>
+  booleanControlFlowNodes.has(parent.type)
+
+let booleanControlFlowNodes = new Set<Node['type']>([
+  'ConditionalExpression',
+  'LogicalExpression',
+  'DoWhileStatement',
+  'UnaryExpression',
+  'WhileStatement',
+  'ForStatement',
+  'IfStatement',
+])
+
+/**
+ * Checks if the given node is part of a comparison operation.
+ *
+ * Supported operators: `===`, `!==`, `==`, `!=`, `<`, `>`, `<=`, `>=`.
+ * @param {Node} parent - The parent node in the AST.
+ * @returns {boolean} True if the node is a part of a binary comparison.
+ */
+let isComparison = (parent: Node): boolean =>
+  parent.type === 'BinaryExpression' && comparisonOperators.has(parent.operator)
+
+let comparisonOperators = new Set<BinaryOperator>([
+  '===',
+  '!==',
+  '==',
+  '!=',
+  '<=',
+  '>=',
+  '<',
+  '>',
+])
+
+/**
+ * Checks if the given node is passed to a function that explicitly converts it
+ * to a boolean.
+ * @param {Node} parent - The parent node in the AST.
+ * @returns {boolean} True if the node is passed to `Boolean()`.
+ */
+let isBooleanFunction = (parent: Node): boolean =>
+  parent.type === 'CallExpression' &&
+  parent.callee.type === 'Identifier' &&
+  parent.callee.name === 'Boolean'

--- a/utils/has-negation-inside-parentheses.ts
+++ b/utils/has-negation-inside-parentheses.ts
@@ -1,0 +1,46 @@
+import type { Expression, Node } from 'estree'
+import type { Rule } from 'eslint'
+
+import { findOutermostParenthesizedNode } from './find-outermost-parenthesized-node'
+import { isLogicalExpression } from './is-logical-expression'
+import { isUnaryExpression } from './is-unary-expression'
+import { getSourceCode } from './get-source-code'
+
+/**
+ * Recursively checks if the given expression contains a negation (`!`) inside.
+ * @param {Expression} node - The AST expression node to check.
+ * @returns {boolean} True if the expression contains `!` inside.
+ */
+let hasNegationInside = (node: Node): boolean => {
+  if (isUnaryExpression(node) && node.operator === '!') {
+    return true
+  }
+  if (isLogicalExpression(node)) {
+    return hasNegationInside(node.left) || hasNegationInside(node.right)
+  }
+  return false
+}
+
+/**
+ * Checks if there is a negation (`!`) inside the outermost parentheses of a
+ * given negated expression. This is useful for determining if De Morgan's laws
+ * can be applied without changing the logic.
+ * @param {Expression} node - The starting node, assumed to be of the form
+ * `!(...)`.
+ * @param {Rule.RuleContext} context - The ESLint rule context, used to access
+ * source code.
+ * @returns {boolean} True if there is a negation (`!`) inside the parentheses.
+ */
+export let hasNegationInsideParentheses = (
+  node: Expression,
+  context: Rule.RuleContext,
+): boolean => {
+  let sourceCode = getSourceCode(context).getText(node)
+  let outermostNode = findOutermostParenthesizedNode(node, sourceCode)
+
+  if (!isUnaryExpression(outermostNode)) {
+    return false
+  }
+
+  return hasNegationInside(outermostNode.argument)
+}

--- a/utils/is-pure-group.ts
+++ b/utils/is-pure-group.ts
@@ -1,62 +1,11 @@
 import type { Expression, Node } from 'estree'
 import type { Rule } from 'eslint'
 
-import { isLogicalExpression } from './is-logical-expression'
+import { findOutermostParenthesizedNode } from './find-outermost-parenthesized-node'
 import { getNodeContent } from './get-node-content'
 import { getSourceCode } from './get-source-code'
 
 type ParentedNode = { parent?: ParentedNode } & Node
-
-/**
- * Checks if the characters immediately before and at the end of the given
- * node's range in the source code form a pair of parentheses.
- * @param {number} start - The start index of the node's range.
- * @param {number} end - The end index of the node's range.
- * @param {string} sourceCode - The full source code text.
- * @returns {boolean} True if the character immediately before start is `(` and
- * the character at index end is `)`, false otherwise.
- */
-let isInParentheses = (
-  start: number,
-  end: number,
-  sourceCode: string,
-): boolean => sourceCode[start - 1] === '(' && sourceCode[end] === ')'
-
-/**
- * Traverses up the parent chain of the given node (if available) to find the
- * outermost logical expression node that is explicitly wrapped in parentheses.
- * The function checks the node and its parents (while they are
- * LogicalExpression) and returns the first node that is wrapped in parentheses
- * (i.e. where the characters immediately before its range and at its end form a
- * matching pair of parentheses). If none is found, the function returns the
- * topmost LogicalExpression.
- * @param {ParentedNode} node - The starting expression node.
- * @param {string} sourceCode - The full source code text.
- * @returns {ParentedNode} The outermost parenthesized node found in the parent
- * chain.
- */
-let findOutermostParenthesizedNode = (
-  node: ParentedNode,
-  sourceCode: string,
-): ParentedNode => {
-  let current = node
-  let [start, end] = current.range!
-
-  if (isInParentheses(start, end, sourceCode)) {
-    return current
-  }
-
-  while (current.parent && isLogicalExpression(current)) {
-    current = current.parent
-    ;[start, end] = current.range!
-
-    if (isInParentheses(start, end, sourceCode)) {
-      return current
-    }
-  }
-
-  return current
-}
 
 /**
  * Extracts the inner code from a code string that is wrapped in parentheses. If


### PR DESCRIPTION
### Description

This PR improves the safety of De Morgan transformations by ensuring that negations are only applied in contexts where they do not alter the logic of the code.

- Added a check for boolean context (if, while, Boolean(), etc.) to ensure transformations occur in places where boolean values are expected.
- Implemented a validation that all elements inside the parentheses are positive (i.e., without !) before applying De Morgan’s laws.
- Refactored internal logic for better readability and maintainability.

### Additional context

#2.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-de-morgan/blob/main/contributing.md).
