### PR TITLE
feat!: move to esm only

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "repository": "azat-io/eslint-plugin-de-morgan",
   "license": "MIT",
   "author": "Azat S. <to@azat.io>",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,51 +1,34 @@
 import { prettierFormat } from 'vite-plugin-prettier-format'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import fs from 'node:fs/promises'
 import path from 'node:path'
 
 export default defineConfig({
   build: {
+    lib: {
+      entry: [path.resolve(import.meta.dirname, 'index.ts')],
+      fileName: (_format, entryName) => `${entryName}.js`,
+      name: 'eslint-plugin-de-morgan',
+      formats: ['es'],
+    },
     rollupOptions: {
-      onwarn: (warning, warn) => {
-        let suppressedCodes = ['MIXED_EXPORTS']
-
-        if (!suppressedCodes.includes(warning.code ?? '')) {
-          warn(warning)
-        }
-      },
+      external: (id: string) => !id.startsWith('.') && !path.isAbsolute(id),
       output: {
         preserveModules: true,
-        exports: 'auto',
       },
-      external: (id: string) => !id.startsWith('.') && !path.isAbsolute(id),
-    },
-    lib: {
-      fileName: (_format, entryName) => `${entryName}.js`,
-      entry: [path.resolve(__dirname, 'index.ts')],
-      name: 'eslint-plugin-de-morgan',
-      formats: ['cjs'],
     },
     minify: false,
   },
   plugins: [
     dts({
-      afterBuild: async () => {
-        await fs.writeFile(
-          'dist/index.d.ts',
-          `${(await fs.readFile('dist/index.d.ts'))
-            .toString()
-            .replace(/\nexport .+/u, '')}export = _default`,
-        )
-      },
       include: [
-        path.join(__dirname, 'index.ts'),
-        path.join(__dirname, 'rules'),
-        path.join(__dirname, 'utils'),
+        path.join(import.meta.dirname, 'index.ts'),
+        path.join(import.meta.dirname, 'rules'),
+        path.join(import.meta.dirname, 'utils'),
       ],
       insertTypesEntry: true,
       strictOutput: true,
-      rollupTypes: true,
+      copyDtsFiles: true,
     }),
     prettierFormat(),
   ],


### PR DESCRIPTION
### Description

Move to ESM only.

### Additional context

v2.0.0.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
- [x] Read [contribution guidelines](https://github.com/azat-io/eslint-plugin-de-morgan/blob/main/contributing.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched package distribution to ES Modules and removed CommonJS output.
  * Updated build configuration to produce ES module bundles only.
  * Simplified TypeScript declaration generation by relying on the plugin’s copy behavior.

* **Refactor**
  * Streamlined build setup by removing custom post-build steps and warning suppressions.

Impact: Consumers must use ESM-compatible imports. CommonJS require() usage is no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->